### PR TITLE
fix(priority): table.insert idx 0 fails

### DIFF
--- a/spec/mediator_spec.lua
+++ b/spec/mediator_spec.lua
@@ -1,8 +1,9 @@
 describe("mediator", function()
-  local Mediator = require 'mediator'
+  local Mediator
   local m, c, testfn, testfn2, testfn3
 
   before_each(function()
+    Mediator = require("mediator")
     m = Mediator()
     c = Mediator.Channel("test")
     testfn = function() end
@@ -66,6 +67,21 @@ describe("mediator", function()
     c:setPriority(sub1.id, 2)
 
     assert.are.equal(c.callbacks[2], sub1)
+  end)
+
+  it("keeps subscriber priority within bounds upon change", function()
+    local sub1 = c:addSubscriber(testfn)
+    local sub2 = c:addSubscriber(testfn2)
+    assert.are.equal(c.callbacks[1], sub1)
+    assert.are.equal(c.callbacks[2], sub2)
+
+    c:setPriority(sub1.id, 99)
+    assert.are.equal(c.callbacks[2], sub1)
+    assert.are.equal(c.callbacks[1], sub2)
+
+    c:setPriority(sub1.id, 0)
+    assert.are.equal(c.callbacks[1], sub1)
+    assert.are.equal(c.callbacks[2], sub2)
   end)
 
   it("can add subchannels", function()

--- a/src/mediator.lua
+++ b/src/mediator.lua
@@ -29,17 +29,13 @@ local function Channel(namespace, parent)
     parent = parent,
 
     addSubscriber = function(self, fn, options)
-      local callback = Subscriber(fn, options)
-      local priority = (#self.callbacks + 1)
-
       options = options or {}
 
-      if options.priority and
-        options.priority >= 0 and
-        options.priority < priority
-      then
-          priority = options.priority
-      end
+      local priority = options.priority or (#self.callbacks + 1)
+      priority = math.max(math.min(math.floor(priority), #self.callbacks + 1), 1)
+      options.priority = nil
+
+      local callback = Subscriber(fn, options)
 
       table.insert(self.callbacks, priority, callback)
 
@@ -61,6 +57,8 @@ local function Channel(namespace, parent)
 
     setPriority = function(self, id, priority)
       local callback = self:getSubscriber(id)
+
+      priority = math.max(math.min(math.floor(priority), #self.callbacks), 1)
 
       if callback.value then
         table.remove(self.callbacks, callback.index)

--- a/src/mediator.lua
+++ b/src/mediator.lua
@@ -43,16 +43,13 @@ local function Channel(namespace, parent)
     end,
 
     getSubscriber = function(self, id)
-      for i=1, #self.callbacks do
-        local callback = self.callbacks[i]
+      for i, callback in ipairs(self.callbacks) do
         if callback.id == id then return { index = i, value = callback } end
       end
-      local sub
       for _, channel in pairs(self.channels) do
-        sub = channel:getSubscriber(id)
-        if sub then break end
+        local sub = channel:getSubscriber(id)
+        if sub then return sub end
       end
-      return sub
     end,
 
     setPriority = function(self, id, priority)

--- a/src/mediator.lua
+++ b/src/mediator.lua
@@ -2,11 +2,11 @@ local function getUniqueId(obj)
   return tonumber(tostring(obj):match(':%s*[0xX]*(%x+)'), 16)
 end
 
-local function Subscriber(fn, options)
+local function Subscriber(fn, options, channel)
   local sub = {
     options = options or {},
     fn = fn,
-    channel = nil,
+    channel = channel,
     update = function(self, options)
       if options then
         self.fn = options.fn or self.fn
@@ -22,7 +22,6 @@ end
 
 local function Channel(namespace, parent)
   return {
-    stopped = false,
     namespace = namespace,
     callbacks = {},
     channels = {},
@@ -35,7 +34,7 @@ local function Channel(namespace, parent)
       priority = math.max(math.min(math.floor(priority), #self.callbacks + 1), 1)
       options.priority = nil
 
-      local callback = Subscriber(fn, options)
+      local callback = Subscriber(fn, options, self)
 
       table.insert(self.callbacks, priority, callback)
 


### PR DESCRIPTION
fixes the range of the priority setting to acceptable range.
also minor refactors (unused properties)